### PR TITLE
Add fastqc for trimming and alignment target rules

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -198,13 +198,13 @@ def get_index_input():
 def get_trimming_input():
 
 	trimming_input = [f"{OUTDIR}/multiqc/multiqc_files_report.html"]
-	'''
+	
 	for sample in samples['sample']:
 		if is_single_end(sample):
 			trimming_input += [f"{OUTDIR}/qc/fastqc_concat/{sample}_R1_fastqc.html"]
 		else:
 			trimming_input += expand(f"{OUTDIR}/qc/fastqc_concat/{sample}_R{{strand}}_fastqc.html", strand=[1,2])
-	'''
+	
 	for sample in samples['sample']:
 		if is_single_end(sample):
 			trimming_input += [f"{OUTDIR}/trimmed/{sample}/{sample}_R1.fastq.gz"]
@@ -218,13 +218,13 @@ def get_trimming_input():
 def get_alignment_input():
 
 	alignment_input = [f"{OUTDIR}/multiqc/multiqc_files_report.html"]
-	'''
+	
 	for sample in samples['sample']:
 		if is_single_end(sample):
 			alignment_input += [f"{OUTDIR}/qc/fastqc_concat/{sample}_R1_fastqc.html"]
 		else:
 			alignment_input += expand(f"{OUTDIR}/qc/fastqc_concat/{sample}_R{{strand}}_fastqc.html", strand=[1,2])
-	'''
+	
 	if chosen_aligner == "salmon":
 		alignment_input += expand(f"{OUTDIR}/quant/salmon/{{sample}}/quant.sf", sample=samples['sample'])
 	else:


### PR DESCRIPTION
Ask fastqc for concat files in trimming and align target rules after remove multiQC to avoid problems with computation in cluster environments