### PR TITLE
Solve problem of quantification with FeatureCounts

### DIFF
--- a/rules/quantification.smk
+++ b/rules/quantification.smk
@@ -1,7 +1,7 @@
 def featurecounts_args(sample):
     pars = ""
     if single_end == False:
-        pars = "-p"
+        pars = "-p --countReadPairs"
     return pars
 
 

--- a/template_config.yaml
+++ b/template_config.yaml
@@ -109,10 +109,7 @@ parameters:
     htseq-count:
         # Extra parameters for htseq-count are available in the documentation: 
         # https://htseq.readthedocs.io/en/release_0.11.1/count.html
-        # A recommended extra parameter is '-i', which indicates the GTF attribute 
-        # to be used as feature ID to identify the counts in the output table.
-        # e.g. "-i 'gene_id'" for ENSEMBL gene IDs or "-i 'gene_name'" for gene SYMBOL
-        extra: "-i 'gene_id'"
+        extra: "-i 'gene_name'"
         # Mode: "union", "intersection-strict" or "intersection-nonempty" (default: union)
         # If your data is Lexogen QuantSeq 3‘ mRNA-Seq, use the intersection-nonempty mode
         mode: "-m union"
@@ -122,12 +119,7 @@ parameters:
     featureCounts:
         # Extra parameters for featureCounts are available in the documentation:
         # https://bioconductor.org/packages/release/bioc/vignettes/Rsubread/inst/doc/SubreadUsersGuide.pdf
-        # Feature type ('-t') sets to gene by default for read counting because it 
-        # seems that improve the results. e.g. "-t 'gene' or "-t 'exon'"
-        # Attribute type ('-g') is used to group features (eg. exons or genes) into 
-        # meta-features (eg. genes) when GTF annotation is provided.
-        # e.g. "-g 'gene id'" for ENSEMBL gene IDs or "-g 'gene_name'" for gene SYMBOL
-        extra: "-t 'gene' -g 'gene_id'"
+        extra: "-g 'gene_name'"
         # Strandness: 0 = "unstranded", 1 = "stranded", 2 = "reversely stranded" (default: 0)
         strandedness: "-s 1"
 


### PR DESCRIPTION
In the config file, the extra -t parameter for featureCounts has been removed. This ensures reads are assigned to exons (the default -t value) rather than genes. This prevents multi-overlapping reads from being ignored due to overlapping gene coordinates, while still counting reads correctly at the exon level, which is the intended counting unit.

For paired-end RNA-seq, in quantification.smk the --countReadPairs option has been added to the featureCounts configuration. This ensures that reads from the same fragment are counted as a single unit rather than separately, giving accurate quantification for paired-end data.